### PR TITLE
BREAKING CHANGES: Bucket name validation, internal URL usage, and custom endpoint resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Packages
 xcuserdata/
 .env.testing
 
+
+DerivedData/

--- a/Sources/LiquidAwsS3Driver/FileStorageConfiguration+AwsS3.swift
+++ b/Sources/LiquidAwsS3Driver/FileStorageConfiguration+AwsS3.swift
@@ -12,17 +12,13 @@ public extension FileStorageConfigurationFactory {
                       bucket: String,
                       region: Region,
                       endpoint: String? = nil) throws -> FileStorageConfigurationFactory {
-        do {
-            let config = try LiquidAwsS3StorageConfiguration(key: key,
-                                                             secret: secret,
-                                                             bucket: bucket,
-                                                             region: region,
-                                                             endpoint: endpoint)
-            return .init {
-                return config
-            }
-        } catch {
-            fatalError("Error creating LiquidAwsS3StorageConfiguration \(error)")
+        let config = try LiquidAwsS3StorageConfiguration(key: key,
+                                                         secret: secret,
+                                                         bucket: bucket,
+                                                         region: region,
+                                                         endpoint: endpoint)
+        return .init {
+            return config
         }
     }
 }

--- a/Sources/LiquidAwsS3Driver/FileStorageConfiguration+AwsS3.swift
+++ b/Sources/LiquidAwsS3Driver/FileStorageConfiguration+AwsS3.swift
@@ -11,11 +11,18 @@ public extension FileStorageConfigurationFactory {
                       secret: String,
                       bucket: String,
                       region: Region,
-                      endpoint: String? = nil) -> FileStorageConfigurationFactory {
-        .init { LiquidAwsS3StorageConfiguration(key: key,
-                                                secret: secret,
-                                                bucket: bucket,
-                                                region: region,
-                                                endpoint: endpoint) }
+                      endpoint: String? = nil) throws -> FileStorageConfigurationFactory {
+        do {
+            let config = try LiquidAwsS3StorageConfiguration(key: key,
+                                                             secret: secret,
+                                                             bucket: bucket,
+                                                             region: region,
+                                                             endpoint: endpoint)
+            return .init {
+                return config
+            }
+        } catch {
+            fatalError("Error creating LiquidAwsS3StorageConfiguration \(error)")
+        }
     }
 }

--- a/Sources/LiquidAwsS3Driver/LiquidAwsS3Storage.swift
+++ b/Sources/LiquidAwsS3Driver/LiquidAwsS3Storage.swift
@@ -5,7 +5,7 @@
 //  Created by Tibor Bodecs on 2020. 04. 28..
 //
 
-import struct Foundation.Data
+import Foundation
 import AWSS3
 
 struct LiquidAwsS3Storage: FileStorage {
@@ -30,12 +30,21 @@ struct LiquidAwsS3Storage: FileStorage {
         self.configuration.bucket
     }
 
-    private var publicUrl: String {
-        "https://\(self.configuration.bucket).s3-\(self.configuration.region.rawValue).amazonaws.com/"
+    private var publicUrl: URL {
+        if let endpointStr = self.configuration.endpoint, let endpointURL = URL(string: endpointStr) {
+            return endpointURL.appendingPathComponent(self.configuration.bucket)
+        } else {
+            var components = URLComponents()
+            components.scheme = "https"
+            components.host = "\(self.configuration.bucket).s3-\(self.configuration.region.rawValue).amazonaws.com"
+            // force unwrap is justified by the bucket naming validation step to init the configuration; there should be
+            // no possible bucket or region that would result in an invalid url.
+            return components.url!
+        }
     }
 
     func resolve(key: String) -> String {
-        self.publicUrl + key
+        self.publicUrl.appendingPathComponent(key).absoluteString
     }
     
     func upload(key: String, data: Data) -> EventLoopFuture<String> {
@@ -48,7 +57,7 @@ struct LiquidAwsS3Storage: FileStorage {
 
         return self.s3.putObject(putRequest).map { output in
             print(output)
-            return self.publicUrl + key
+            return self.resolve(key: key)
         }
     }
 

--- a/Sources/LiquidAwsS3Driver/LiquidAwsS3Storage.swift
+++ b/Sources/LiquidAwsS3Driver/LiquidAwsS3Storage.swift
@@ -34,12 +34,7 @@ struct LiquidAwsS3Storage: FileStorage {
         if let endpointStr = self.configuration.endpoint, let endpointURL = URL(string: endpointStr) {
             return endpointURL.appendingPathComponent(self.configuration.bucket)
         } else {
-            var components = URLComponents()
-            components.scheme = "https"
-            components.host = "\(self.configuration.bucket).s3-\(self.configuration.region.rawValue).amazonaws.com"
-            // force unwrap is justified by the bucket naming validation step to init the configuration; there should be
-            // no possible bucket or region that would result in an invalid url.
-            return components.url!
+			return URL(string: "https://\(self.configuration.bucket).s3-\(self.configuration.region.rawValue).amazonaws.com")!
         }
     }
 

--- a/Sources/LiquidAwsS3Driver/LiquidAwsS3Storage.swift
+++ b/Sources/LiquidAwsS3Driver/LiquidAwsS3Storage.swift
@@ -34,7 +34,7 @@ struct LiquidAwsS3Storage: FileStorage {
         if let endpointStr = self.configuration.endpoint, let endpointURL = URL(string: endpointStr) {
             return endpointURL.appendingPathComponent(self.configuration.bucket)
         } else {
-			return URL(string: "https://\(self.configuration.bucket).s3-\(self.configuration.region.rawValue).amazonaws.com")!
+            return URL(string: "https://\(self.configuration.bucket).s3-\(self.configuration.region.rawValue).amazonaws.com")!
         }
     }
 

--- a/Sources/LiquidAwsS3Driver/LiquidAwsS3StorageConfiguration.swift
+++ b/Sources/LiquidAwsS3Driver/LiquidAwsS3StorageConfiguration.swift
@@ -4,13 +4,47 @@
 //
 //  Created by Tibor Bodecs on 2020. 04. 28..
 //
+import Foundation
 
 struct LiquidAwsS3StorageConfiguration: FileStorageConfiguration {
+    enum S3ConfigurationError: Error {
+        case invalidBucketName
+    }
+
     let key: String
     let secret: String
     let bucket: String
     let region: Region
     let endpoint: String?
+
+    init(key: String, secret: String, bucket: String, region: Region, endpoint: String?) throws {
+        guard Self.validate(bucketName: bucket) else {
+            throw S3ConfigurationError.invalidBucketName
+        }
+        self.key = key
+        self.secret = secret
+        self.bucket = bucket
+        self.region = region
+        self.endpoint = endpoint
+    }
+
+    /// Validates bucket naming rules based on https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+    /// note this does not account for the rule disallowing IP Addresses, nor does it check uniqueness or other special cases
+    private static func validate(bucketName: String) -> Bool {
+        let legalBucketStartAndFinishCharacterSet: CharacterSet = CharacterSet.lowercaseLetters
+            .union(.decimalDigits)
+        let legalBucketCharacterSet: CharacterSet = legalBucketStartAndFinishCharacterSet.union(CharacterSet(charactersIn: ".-"))
+
+        guard bucketName.count >= 3,
+            bucketName.count <= 63,
+            bucketName.unicodeScalars.allSatisfy({ legalBucketCharacterSet.contains($0) }),
+            let first = bucketName.first,
+            first.unicodeScalars.allSatisfy({ legalBucketStartAndFinishCharacterSet.contains($0) }),
+            let last = bucketName.last,
+            last.unicodeScalars.allSatisfy({ legalBucketStartAndFinishCharacterSet.contains($0) })
+            else { return false }
+        return true
+    }
     
     func makeDriver(for databases: FileStorages) -> FileStorageDriver {
         return LiquidAwsS3StorageDriver(configuration: self)

--- a/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
+++ b/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
@@ -12,7 +12,7 @@ final class LiquidAwsS3DriverTests: XCTestCase {
     private func createTestStorage(withEndpoint endpoint: String? = nil) -> FileStorage {
         let eventLoop = EmbeddedEventLoop()
         let storages = FileStorages(fileio: .init(threadPool: .init(numberOfThreads: 1)))
-		storages.use(try! .awsS3(key: self.key, secret: self.secret, bucket: self.bucket, region: self.region, endpoint: endpoint), as: .awsS3)
+        storages.use(try! .awsS3(key: self.key, secret: self.secret, bucket: self.bucket, region: self.region, endpoint: endpoint), as: .awsS3)
         return storages.fileStorage(.awsS3, logger: .init(label: ""), on: eventLoop)!
     }
 

--- a/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
+++ b/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
@@ -12,7 +12,7 @@ final class LiquidAwsS3DriverTests: XCTestCase {
     private func createTestStorage(withEndpoint endpoint: String? = nil) -> FileStorage {
         let eventLoop = EmbeddedEventLoop()
         let storages = FileStorages(fileio: .init(threadPool: .init(numberOfThreads: 1)))
-        storages.use(try! .awsS3(key: self.key, secret: self.secret, bucket: self.bucket, region: self.region), as: .awsS3)
+		storages.use(try! .awsS3(key: self.key, secret: self.secret, bucket: self.bucket, region: self.region, endpoint: endpoint), as: .awsS3)
         return storages.fileStorage(.awsS3, logger: .init(label: ""), on: eventLoop)!
     }
 

--- a/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
+++ b/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
@@ -5,10 +5,11 @@ final class LiquidAwsS3DriverTests: XCTestCase {
     
     let key = "****"
     let secret = "****"
-    let bucket = "****"
+    let bucket = "bucket"
     let region = Region.uswest1
+    let customEndpoint = "https://s3.wasabisys.com/"
 
-    private func createTestStorage() -> FileStorage {
+    private func createTestStorage(withEndpoint endpoint: String? = nil) -> FileStorage {
         let eventLoop = EmbeddedEventLoop()
         let storages = FileStorages(fileio: .init(threadPool: .init(numberOfThreads: 1)))
         storages.use(.awsS3(key: self.key, secret: self.secret, bucket: self.bucket, region: self.region), as: .awsS3)
@@ -25,5 +26,13 @@ final class LiquidAwsS3DriverTests: XCTestCase {
         let data = Data("file storage test".utf8)
         let res = try fs.upload(key: key, data: data).wait()
         XCTAssertEqual(res, "https://\(self.bucket).s3-\(self.region.rawValue).amazonaws.com/\(key)")
+    }
+
+    func testCustomEndpointUpload() throws {
+        let fs = self.createTestStorage(withEndpoint: customEndpoint)
+        let key = "test"
+        let data = Data("file storage test".utf8)
+        let res = try fs.upload(key: key, data: data).wait()
+        XCTAssertEqual(res, "\(self.customEndpoint)\(self.bucket)/\(key)")
     }
 }

--- a/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
+++ b/Tests/LiquidAwsS3DriverTests/LiquidAwsS3DriverTests.swift
@@ -7,7 +7,7 @@ final class LiquidAwsS3DriverTests: XCTestCase {
     let secret = "****"
     let bucket = "bucket"
     let region = Region.uswest1
-    let customEndpoint = "https://s3.wasabisys.com/"
+    let customEndpoint = "https://s3.custom.com/"
 
     private func createTestStorage(withEndpoint endpoint: String? = nil) -> FileStorage {
         let eventLoop = EmbeddedEventLoop()


### PR DESCRIPTION
Tests were failing when I cloned, so I haven't thoroughly tested the custom endpoint resolution.

I'm sure many of these changes will warrant discussion, but I've provided some preliminary reasoning in comments.